### PR TITLE
Add build caching and migrate to circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - run: git submodule update --init --recursive
       - run: make
       - run: make multirelease
+
   langstroth:
     docker:
       - image: java:8
@@ -21,9 +22,19 @@ jobs:
     steps:
       - checkout:
           path: ~/beekeeper
-      - run: ./gradlew assemble
+
+      - restore_cache:
+          key: langstorth-gradle-{{ checksum "build.gradle" }}
+
+      # build
+      - run: ./gradlew --no-daemon assemble
       # tests
-      - run: ./gradlew check
+      - run: ./gradlew --no-daemon check
+
+      - save_cache:
+          key: langstorth-gradle-{{ checksum "build.gradle" }}
+          paths:
+            - ~/.gradle
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,29 +1,7 @@
-# https://circleci.com/docs/2.0/defining-multiple-jobs/
+# https://circleci.com/docs/2.0/workflows/
 # Using the new circleci 2.0 beta!
-
 version: 2
 jobs:
-  build:
-    working_directory: ~/beekeeper
-    docker:
-      - image: alpine:latest
-    steps:
-      - run: apk add --update curl
-      - run:
-            name: Trigger Jobs
-            command: |
-              # a similar function will liekly get built in into the circleci cli
-              function trigger_job() {
-                job_name=$1
-                curl -u ${CIRCLE_API_TOKEN}: \
-                  -d build_parameters[CIRCLE_JOB]=${job_name} \
-                  -d revision=$CIRCLE_SHA1 \
-                  https://circleci.com/api/v1.1/project/github/RoboJackets/beekeeper/tree/$CIRCLE_BRANCH
-              }
-              trigger_job smoker
-              trigger_job langstroth
-
-  # Run our tasks as independent jobs
   smoker:
     docker:
       - image: golang:1.8.3
@@ -36,7 +14,6 @@ jobs:
       - run: git submodule update --init --recursive
       - run: make
       - run: make multirelease
-
   langstroth:
     docker:
       - image: java:8
@@ -47,3 +24,10 @@ jobs:
       - run: ./gradlew assemble
       # tests
       - run: ./gradlew check
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - smoker
+      - langstroth

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# beekeeper [![CircleCI](https://circleci.com/gh/RoboJackets/beekeeper.svg?style=svg)](https://circleci.com/gh/RoboJackets/beekeeper)
+# beekeeper [![CircleCI](https://circleci.com/gh/RoboJackets/beekeeper.svg?style=shield)](https://circleci.com/gh/RoboJackets/beekeeper)
 Acclimating a new generation to high altitudes.
 
 ## Langstroth (Backend API)


### PR DESCRIPTION
This PR adds support for build caching and migrates to circleci workflows (which replace the old way of getting parallel builds.

https://circleci.com/docs/2.0/workflows/
https://circleci.com/docs/2.0/caching/

Shouldn't affect anyone, so I'll merge unless someone objects.