### PR TITLE
Smoker Serialization to File

### DIFF
--- a/smoker/makefile
+++ b/smoker/makefile
@@ -18,7 +18,11 @@ clean:
 run: all
 	@./bin/smoker
 
+run-rlwrap: all
+	@rlwrap ./bin/smoker
+
 r: run
+rr: run-rlwrap
 
 win:
 	export GOPATH=`pwd` && GOOS=windows GOARCH=amd64 go build -o bin/smoker.exe smoker/smoker

--- a/smoker/src/smoker/backends/backend.go
+++ b/smoker/src/smoker/backends/backend.go
@@ -20,13 +20,17 @@ type Backend interface {
 	GetAllBinNames() []string
 	// Return a CredentialManager to handle me Auth
 	GetCredentialManager() CredentialManager
+
+	// Save/Restore backend data. These are optional, just throw an error if we can't do this.
+	SaveToFile(string) error
+	RestoreFromFile(string) error
 }
 
 type Bin interface {
 	GetName() string
 	GetCapacity() uint
-	GetParts() []Component
-	deletePart(Component)
+	GetParts() []uint
+	deletePart(uint)
 }
 
 type Component interface {
@@ -35,8 +39,9 @@ type Component interface {
 	GetId() uint
 	GetCount() uint
 	SetCount(uint)
-	GetBin() Bin
-	setBin(Bin)
+	// the string here is the unique bin name, same as returned from GetAllBinNames()
+	GetBin() string
+	setBin(string)
 	// Return true if the input string matches any field in this component
 	// Ex: A0 should return true if we are in bin A0, or if we are "resistor A0"
 	MatchStr(string) bool

--- a/smoker/src/smoker/backends/backend.go
+++ b/smoker/src/smoker/backends/backend.go
@@ -23,7 +23,7 @@ type Backend interface {
 
 	// Save/Restore backend data. These are optional, just throw an error if we can't do this.
 	SaveToFile(string) error
-	RestoreFromFile(string) error
+	LoadFromFile(string) error
 }
 
 type Bin interface {

--- a/smoker/src/smoker/backends/backend.go
+++ b/smoker/src/smoker/backends/backend.go
@@ -22,7 +22,7 @@ type Backend interface {
 	GetCredentialManager() CredentialManager
 
 	// Save/Restore backend data. These are optional, just throw an error if we can't do this.
-	SaveToFile(string) error
+	SaveToFile(string, bool) error
 	LoadFromFile(string) error
 }
 

--- a/smoker/src/smoker/backends/dummybackend.go
+++ b/smoker/src/smoker/backends/dummybackend.go
@@ -256,6 +256,7 @@ func NewDummyCredentialManager() CredentialManager {
 }
 
 // ** DummyBackend
+// *** Def
 type DummyBackend struct {
 	// Map of component ID to component
 	// Use this for most lookups
@@ -265,6 +266,9 @@ type DummyBackend struct {
 
 	AuthManager CredentialManager
 }
+
+// *** Constructors
+// TODO refactor constructors into their own sections
 
 // Makes a very simple backend.
 // If specifying a number <= 0, 1 is defaulted to
@@ -310,6 +314,8 @@ func NewComponent(id, count uint, name, manufacturer string) Component {
 		Manufacturer: manufacturer}
 }
 
+// *** Data Dump Functions
+
 // Gets all the components in this dummybackend
 func (b *DummyBackend) GetAllComponents() []Component {
 	comp := make([]Component, 0)
@@ -327,6 +333,8 @@ func (b *DummyBackend) GetAllBinNames() []string {
 	}
 	return bins
 }
+
+// *** Component Modification
 
 // Adds the component to the bin we think is the most suitable
 func (b *DummyBackend) AddComponent(comp Component) (Bin, error) {
@@ -412,6 +420,7 @@ func (b *DummyBackend) GetCredentialManager() CredentialManager {
 	return b.AuthManager
 }
 
+// *** Serialization
 func (b *DummyBackend) SaveToFile(path string) error {
 	file, err := os.Create(path)
 	if err == nil {
@@ -421,7 +430,7 @@ func (b *DummyBackend) SaveToFile(path string) error {
 	file.Close()
 	return err
 }
-func (b *DummyBackend) RestoreFromFile(path string) error {
+func (b *DummyBackend) LoadFromFile(path string) error {
 	file, err := os.Open(path)
 	if err == nil {
 		decoder := gob.NewDecoder(file)

--- a/smoker/src/smoker/backends/dummybackend.go
+++ b/smoker/src/smoker/backends/dummybackend.go
@@ -3,7 +3,6 @@ package backends
 import (
 	"encoding/gob"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"os"
@@ -416,7 +415,7 @@ func (b *DummyBackend) SaveToFile(path string) error {
 	file, err := os.Create(path)
 	if err == nil {
 		encoder := gob.NewEncoder(file)
-		encoder.Encode(*b)
+		err = encoder.Encode(b)
 	}
 	file.Close()
 	return err
@@ -425,10 +424,7 @@ func (b *DummyBackend) RestoreFromFile(path string) error {
 	file, err := os.Open(path)
 	if err == nil {
 		decoder := gob.NewDecoder(file)
-		fmt.Println(b)
-		fmt.Println("Decoding")
-		err = decoder.Decode(*b)
-		fmt.Println(b)
+		err = decoder.Decode(b)
 	}
 	file.Close()
 	return err

--- a/smoker/src/smoker/backends/dummybackend.go
+++ b/smoker/src/smoker/backends/dummybackend.go
@@ -3,9 +3,9 @@ package backends
 import (
 	"encoding/gob"
 	"errors"
+	"os"
 	"strconv"
 	"strings"
-	"os"
 )
 
 // * Dummy Type Definitions
@@ -138,6 +138,7 @@ func (c *DummyCredentialManager) AddCredential(cred Credential) error {
 	c.Creds[cred.GetUsername()] = cred
 	return nil
 }
+
 // Determines the current number of admins (highest privleges)
 func (c *DummyCredentialManager) numOfAdministrators() uint {
 	var count uint = 0

--- a/smoker/src/smoker/backends/dummybackend.go
+++ b/smoker/src/smoker/backends/dummybackend.go
@@ -429,3 +429,12 @@ func (b *DummyBackend) RestoreFromFile(path string) error {
 	file.Close()
 	return err
 }
+
+// ** Gob Definitions
+func RegisterDummyGob() {
+	gob.Register(&DummyBackend{})
+	gob.Register(&DummyBin{})
+	gob.Register(&DummyComponent{})
+	gob.Register(&PasswordCredential{})
+	gob.Register(&DummyCredentialManager{})
+}

--- a/smoker/src/smoker/backends/dummybackend.go
+++ b/smoker/src/smoker/backends/dummybackend.go
@@ -4,6 +4,8 @@ import (
 	"encoding/gob"
 	"errors"
 	"os"
+	"os/user"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -421,7 +423,19 @@ func (b *DummyBackend) GetCredentialManager() CredentialManager {
 }
 
 // *** Serialization
+// Translates a path with ~ to a path with literal home dir
+func translatePath(path string) string {
+	// TODO catch edge cases for '~' translation
+	usr, _ := user.Current()
+	dir := usr.HomeDir
+	if path[:2] == "~/" {
+		path = filepath.Join(dir, path[2:])
+	}
+	return path
+}
+
 func (b *DummyBackend) SaveToFile(path string, force bool) error {
+	path = translatePath(path)
 	if _, err := os.Stat(path); (err == nil || !os.IsNotExist(err)) && !force {
 		if err == nil {
 			return errors.New(path + " already exists. Use savef to force")
@@ -438,6 +452,7 @@ func (b *DummyBackend) SaveToFile(path string, force bool) error {
 	return err
 }
 func (b *DummyBackend) LoadFromFile(path string) error {
+	path = translatePath(path)
 	file, err := os.Open(path)
 	if err == nil {
 		decoder := gob.NewDecoder(file)

--- a/smoker/src/smoker/backends/dummybackend.go
+++ b/smoker/src/smoker/backends/dummybackend.go
@@ -421,7 +421,14 @@ func (b *DummyBackend) GetCredentialManager() CredentialManager {
 }
 
 // *** Serialization
-func (b *DummyBackend) SaveToFile(path string) error {
+func (b *DummyBackend) SaveToFile(path string, force bool) error {
+	if _, err := os.Stat(path); (err == nil || !os.IsNotExist(err)) && !force {
+		if err == nil {
+			return errors.New(path + " already exists. Use savef to force")
+		}
+		return err
+	}
+
 	file, err := os.Create(path)
 	if err == nil {
 		encoder := gob.NewEncoder(file)

--- a/smoker/src/smoker/backends/dummybackend.go
+++ b/smoker/src/smoker/backends/dummybackend.go
@@ -1,78 +1,81 @@
 package backends
 
 import (
+	"encoding/gob"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
+	"os"
 )
 
 // * Dummy Type Definitions
 // ** DummyBin
 // Represents a bin
 type DummyBin struct {
-	name     string
-	capacity uint
+	Name     string
+	Capacity uint
 
-	parts map[Component]bool
+	Parts map[uint]bool
 }
 
 func (b *DummyBin) GetName() string {
-	return b.name
+	return b.Name
 }
 func (b *DummyBin) GetCapacity() uint {
-	return b.capacity
+	return b.Capacity
 }
 
-func (b *DummyBin) GetParts() []Component {
-	comp := make([]Component, 0)
-	for v := range b.parts {
+func (b *DummyBin) GetParts() []uint {
+	comp := make([]uint, 0)
+	for v := range b.Parts {
 		comp = append(comp, v)
 	}
 
 	return comp
 }
 
-func (b *DummyBin) deletePart(c Component) {
-	delete(b.parts, c)
+func (b *DummyBin) deletePart(c uint) {
+	delete(b.Parts, c)
 }
 
 // ** DummyComponent
 // Represents a component.
 // Probably will be used in all future backends
 type DummyComponent struct {
-	id, count uint
-	owner     Bin
+	Id, Count uint
+	Owner     string
 
-	name, manufacturer string
+	Name, Manufacturer string
 }
 
 func (c *DummyComponent) GetName() string {
-	return c.name
+	return c.Name
 }
 func (c *DummyComponent) GetManufacturer() string {
-	return c.manufacturer
+	return c.Manufacturer
 }
 func (c *DummyComponent) GetId() uint {
-	return c.id
+	return c.Id
 }
-func (c *DummyComponent) GetBin() Bin {
-	return c.owner
+func (c *DummyComponent) GetBin() string {
+	return c.Owner
 }
 func (c *DummyComponent) GetCount() uint {
-	return c.count
+	return c.Count
 }
 func (c *DummyComponent) SetCount(u uint) {
-	c.count = u
+	c.Count = u
 }
-func (c *DummyComponent) setBin(b Bin) {
-	c.owner = b
+func (c *DummyComponent) setBin(b string) {
+	c.Owner = b
 }
 func (c *DummyComponent) MatchStr(s string) bool {
 	totalStr := strings.Join(
 		[]string{c.GetName(),
 			c.GetManufacturer(),
 			strconv.Itoa(int(c.GetId())),
-			c.GetBin().GetName()}, " ")
+			c.GetBin()}, " ")
 	return strings.Contains(strings.ToLower(totalStr), strings.ToLower(s))
 }
 
@@ -167,6 +170,7 @@ func (c *DummyCredentialManager) RemoveCredential(user Credential) error {
 	delete(c.creds, user.GetUsername())
 	return nil
 }
+
 func (c *DummyCredentialManager) DumpUsers() ([]Credential, error) {
 	if currentUser, err := c.CurrentUser(); err != nil {
 		return nil, errors.New("No logged in user.")
@@ -255,11 +259,9 @@ func NewDummyCredentialManager() CredentialManager {
 type DummyBackend struct {
 	// Map of component ID to component
 	// Use this for most lookups
-	idLookup map[uint]Component
-	// Set of all components (for searches)
-	components map[Component]bool
+	IdLookup map[uint]Component
 	// List of all the bins
-	bins []DummyBin
+	bins map[string]DummyBin
 
 	authManager CredentialManager
 }
@@ -271,25 +273,21 @@ func NewDummyBackend(numBins uint) Backend {
 		numBins = 1
 	}
 
-	// TODO remove hard coded number for demo
-	numBins = 2
-
 	idLookup := make(map[uint]Component)
-	components := make(map[Component]bool)
 	newDummy := DummyBackend{
-		idLookup:    idLookup,
-		components:  components,
-		bins:        make([]DummyBin, numBins),
+		IdLookup:    idLookup,
+		bins:        make(map[string]DummyBin),
 		authManager: NewDummyCredentialManager()}
 
 	// Let's make 10 bins, A00 -> A09
-	for i := range newDummy.bins {
-		mp := make(map[Component]bool)
-		newDummy.bins[i] = DummyBin{
-			name:  "A" + "0" + strconv.Itoa(i),
-			parts: mp,
+	for i := 0; i < int(numBins); i++ {
+		mp := make(map[uint]bool)
+		name := "A" + "0" + strconv.Itoa(i)
+		newDummy.bins[name] = DummyBin{
+			Name:  name,
+			Parts: mp,
 			// TODO stop hard coding this
-			capacity: 3}
+			Capacity: 3}
 	}
 
 	// hardcoded bins for demo
@@ -306,10 +304,10 @@ func NewDummyBackend(numBins uint) Backend {
 }
 func NewComponent(id, count uint, name, manufacturer string) Component {
 	return &DummyComponent{
-		id:           id,
-		count:        count,
-		name:         name,
-		manufacturer: manufacturer}
+		Id:           id,
+		Count:        count,
+		Name:         name,
+		Manufacturer: manufacturer}
 }
 
 // Gets all the components in this dummybackend
@@ -317,7 +315,7 @@ func (b *DummyBackend) GetAllComponents() []Component {
 	comp := make([]Component, 0)
 	for _, bin := range b.bins {
 		for _, c := range bin.GetParts() {
-			comp = append(comp, c)
+			comp = append(comp, b.IdLookup[c])
 		}
 	}
 	return comp
@@ -334,7 +332,7 @@ func (b *DummyBackend) GetAllBinNames() []string {
 func (b *DummyBackend) AddComponent(comp Component) (Bin, error) {
 	var selectedBin *DummyBin
 	for _, v := range b.bins {
-		if v.GetCapacity() > uint(len(v.parts)) {
+		if v.GetCapacity() > uint(len(v.Parts)) {
 			selectedBin = &v
 			break
 		}
@@ -344,47 +342,49 @@ func (b *DummyBackend) AddComponent(comp Component) (Bin, error) {
 	}
 
 	// Actually add component to bin
-	selectedBin.parts[comp] = true
-	comp.setBin(selectedBin)
+	selectedBin.Parts[comp.GetId()] = true
+	comp.setBin(selectedBin.GetName())
 
 	// Add lookup pointers for us
-	b.idLookup[comp.GetId()] = comp
-	b.components[comp] = true
+	b.IdLookup[comp.GetId()] = comp
 	return selectedBin, nil
 }
 
 // Moves a component from it's current bin to a valid one
 func (b *DummyBackend) MoveComponent(comp Component, name string) error {
-	if comp.GetBin() == nil {
+	if comp.GetBin() == "" {
 		return errors.New("Comp is not stored in a bin yet!")
 	}
-	if comp.GetBin().GetName() == name {
+	if comp.GetBin() == name {
 		// We are already in the target bin
 		return nil
 	}
 
 	for _, bin := range b.bins {
 		if bin.GetName() == name {
-			if bin.GetCapacity() > uint(len(bin.parts)) {
-				comp.GetBin().deletePart(comp)
-				comp.setBin(&bin)
-				bin.parts[comp] = true
+			if bin.GetCapacity() > uint(len(bin.Parts)) {
+				oldbin := b.bins[comp.GetBin()]
+				oldbin.deletePart(comp.GetId())
+				comp.setBin(bin.GetName())
+				bin.Parts[comp.GetId()] = true
 				// Don't need to touch b.components or b.idLookup
 				return nil
 			}
-			return errors.New("'" + bin.name + "' is over capacity!")
+			return errors.New("'" + bin.GetName() + "' is over capacity!")
 		}
 	}
 	return errors.New("Bin '" + name + "' was not found!")
 }
 func (b *DummyBackend) LookupId(id uint) (Component, Bin, error) {
-	if component, present := b.idLookup[id]; !present {
+	if component, present := b.IdLookup[id]; !present {
 		return nil, nil, errors.New("No component found with that ID.")
 	} else {
-		if component.GetBin() == nil {
+		if component.GetBin() == "" {
 			return nil, nil, errors.New("[INTERNAL] The component found has no bin associated with it.")
 		}
-		return component, component.GetBin(), nil
+		bin := b.bins[component.GetBin()]
+		// TODO take a look at this logic
+		return component, &bin, nil
 	}
 }
 func (b *DummyBackend) GeneralSearch(s string) []Component {
@@ -398,16 +398,38 @@ func (b *DummyBackend) GeneralSearch(s string) []Component {
 	return c
 }
 func (b *DummyBackend) RemoveComponent(comp Component) error {
-	if comp.GetBin() == nil {
+	if comp.GetBin() == "" {
 		return errors.New("The requested component is not present")
 	} else {
-		comp.GetBin().deletePart(comp)
-		comp.setBin(nil)
-		delete(b.idLookup, comp.GetId())
-		delete(b.components, comp)
+		oldBin := b.bins[comp.GetBin()]
+		oldBin.deletePart(comp.GetId())
+		comp.setBin("")
+		delete(b.IdLookup, comp.GetId())
 		return nil
 	}
 }
 func (b *DummyBackend) GetCredentialManager() CredentialManager {
 	return b.authManager
+}
+
+func (b *DummyBackend) SaveToFile(path string) error {
+	file, err := os.Create(path)
+	if err == nil {
+		encoder := gob.NewEncoder(file)
+		encoder.Encode(*b)
+	}
+	file.Close()
+	return err
+}
+func (b *DummyBackend) RestoreFromFile(path string) error {
+	file, err := os.Open(path)
+	if err == nil {
+		decoder := gob.NewDecoder(file)
+		fmt.Println(b)
+		fmt.Println("Decoding")
+		err = decoder.Decode(*b)
+		fmt.Println(b)
+	}
+	file.Close()
+	return err
 }

--- a/smoker/src/smoker/smoker/commands.go
+++ b/smoker/src/smoker/smoker/commands.go
@@ -205,7 +205,7 @@ func replLoad(s []string, b backends.Backend) {
 	if len(s) < 1 {
 		fmt.Println("Please provide a file to load from.")
 	} else {
-		err := b.RestoreFromFile(s[0])
+		err := b.LoadFromFile(s[0])
 		if err != nil {
 			fmt.Println("Error: " + err.Error())
 		}

--- a/smoker/src/smoker/smoker/commands.go
+++ b/smoker/src/smoker/smoker/commands.go
@@ -45,6 +45,7 @@ func initCommands() {
 	commands["s"] = replScan
 
 	commands["save"] = replSave
+	commands["savef"] = replSavef
 	commands["load"] = replLoad
 
 	commands["rm"] = replRm
@@ -132,7 +133,7 @@ List of Commands:`)
 		fmt.Fprintln(w, "(b)ins\tPrints a list of all bins available.")
 		fmt.Fprintln(w, "(g)rep <search>\tGreps all information in every component.")
 		fmt.Fprintln(w, "(s)can*\tLaunches the interactive scanner interface to add/identify parts.\n\t  Takes in Component IDs, which can be printed with a scanner\n\t  (q)uit to exit scanning mode.")
-		fmt.Fprintln(w, "save <file>\tSaves the current inventory database to a file")
+		fmt.Fprintln(w, "save[f] <file>\tSaves the current inventory database to a file. [f] forces overwrites")
 		fmt.Fprintln(w, "load <file>\tLoads the current inventory database from a file")
 		w.Flush()
 		fmt.Println("")
@@ -191,11 +192,16 @@ func replDump(s []string, b backends.Backend) {
 }
 
 func replSave(s []string, b backends.Backend) {
-	// TODO warn before overwriting
+	replSaveRaw(s, b, false)
+}
+func replSavef(s []string, b backends.Backend) {
+	replSaveRaw(s, b, true)
+}
+func replSaveRaw(s []string, b backends.Backend, force bool) {
 	if len(s) < 1 {
 		fmt.Println("Please provide a file to save to.")
 	} else {
-		err := b.SaveToFile(s[0])
+		err := b.SaveToFile(s[0], force)
 		if err != nil {
 			fmt.Println("Error: " + err.Error())
 		}

--- a/smoker/src/smoker/smoker/commands.go
+++ b/smoker/src/smoker/smoker/commands.go
@@ -49,6 +49,9 @@ func initCommands() {
 	commands["scan"] = replScan
 	commands["s"] = replScan
 
+	commands["save"] = replSave
+	commands["load"] = replLoad
+
 	commands["rm"] = replRm
 	commands["r"] = replRm
 
@@ -182,31 +185,34 @@ type UserG struct {
 	idLookup map[uint]uint
 }
 func replDump(s []string, b backends.Backend) {
-	var d  = new(backends.DummyBackend)
-
 	c := b.GetAllComponents()
-	printDump(c)
-
-	fmt.Println("actual data")
-	fmt.Println(b)
-	err := Save("/tmp/smoker.gob", b)
-	// fmt.Println(err)
-	fmt.Println(b)
-
-	fmt.Println("actual loaded data")
-	fmt.Println(d)
-	err = Load("/tmp/smoker.gob", d)
-	fmt.Println(err)
-	fmt.Println(d)
-
-	c = d.GetAllComponents()
-	printDump(c)
 
 	if len(c) == 0 {
 		fmt.Println("No data is present.")
 		return
 	}
 	printDump(c)
+}
+
+func replSave(s []string, b backends.Backend) {
+	if (len(s) < 1) {
+		fmt.Println("Please provide a file to save to.")
+	} else {
+		err := b.SaveToFile(s[0])
+		if err != nil {
+			fmt.Println("Error: " + err.Error())
+		}
+	}
+}
+func replLoad(s []string, b backends.Backend) {
+	if (len(s) < 1) {
+		fmt.Println("Please provide a file to load from.")
+	} else {
+		err := b.RestoreFromFile(s[0])
+		if err != nil {
+			fmt.Println("Error: " + err.Error())
+		}
+	}
 }
 
 func replBins(s []string, b backends.Backend) {

--- a/smoker/src/smoker/smoker/commands.go
+++ b/smoker/src/smoker/smoker/commands.go
@@ -26,12 +26,7 @@ var moveColor = binColor
 // ** Command Definitions
 
 func initCommands() {
-	// TODO move me somewhere more sensible
-	gob.Register(&backends.DummyBackend{})
-	gob.Register(&backends.DummyBin{})
-	gob.Register(&backends.DummyComponent{})
-	gob.Register(&backends.PasswordCredential{})
-	gob.Register(&backends.DummyCredentialManager{})
+	backends.RegisterDummyGob()
 
 	commands = make(map[string]func([]string, backends.Backend))
 	commands["help"] = replHelp
@@ -137,6 +132,8 @@ List of Commands:`)
 		fmt.Fprintln(w, "(b)ins\tPrints a list of all bins available.")
 		fmt.Fprintln(w, "(g)rep <search>\tGreps all information in every component.")
 		fmt.Fprintln(w, "(s)can*\tLaunches the interactive scanner interface to add/identify parts.\n\t  Takes in Component IDs, which can be printed with a scanner\n\t  (q)uit to exit scanning mode.")
+		fmt.Fprintln(w, "save <file>\tSaves the current inventory database to a file")
+		fmt.Fprintln(w, "load <file>\tLoads the current inventory database from a file")
 		w.Flush()
 		fmt.Println("")
 		fmt.Println("Additional pages:")
@@ -195,6 +192,7 @@ func replDump(s []string, b backends.Backend) {
 }
 
 func replSave(s []string, b backends.Backend) {
+	// TODO warn before overwriting
 	if (len(s) < 1) {
 		fmt.Println("Please provide a file to save to.")
 	} else {
@@ -425,7 +423,8 @@ func replUpdate(args []string, b backends.Backend) {
 }
 
 func replWelcome(args []string, b backends.Backend) {
-	fmt.Println("Welcome to Smoker!\n")
+	fmt.Println("Welcome to Smoker!")
+	fmt.Println()
 	fmt.Println("Smoker is the CLI frontend to the BeeKeeper inventory suite.")
 	fmt.Println("It offers quick and easy access to all functionality beekeeper provides, while staying out of your way as much as possible.")
 	fmt.Println()

--- a/smoker/src/smoker/smoker/commands.go
+++ b/smoker/src/smoker/smoker/commands.go
@@ -95,7 +95,7 @@ func runCommand(prompt string, backend backends.Backend) {
 func replHelp(args []string, b backends.Backend) {
 
 	// UserAdmin Help page
-	if (len(args) >= 1 && args[0] == "useradmin") {
+	if len(args) >= 1 && args[0] == "useradmin" {
 		fmt.Println(`This manual page covers user managment commands.
 
 These include deletion/creation of users and setting user permissions.
@@ -140,7 +140,6 @@ List of Commands:`)
 		fmt.Println("\t\t\thelp useradmin")
 	}
 
-
 }
 
 func printDump(c []backends.Component) {
@@ -161,7 +160,7 @@ func Save(path string, object interface{}) error {
 	}
 	file.Close()
 	return err
- }
+}
 
 // Decode Gob file
 func Load(path string, object interface{}) error {
@@ -174,13 +173,13 @@ func Load(path string, object interface{}) error {
 	return err
 }
 
-
 // ** Command Definitions
 // *** Item Commands
 type UserG struct {
 	Name, Pass string
-	idLookup map[uint]uint
+	idLookup   map[uint]uint
 }
+
 func replDump(s []string, b backends.Backend) {
 	c := b.GetAllComponents()
 
@@ -193,7 +192,7 @@ func replDump(s []string, b backends.Backend) {
 
 func replSave(s []string, b backends.Backend) {
 	// TODO warn before overwriting
-	if (len(s) < 1) {
+	if len(s) < 1 {
 		fmt.Println("Please provide a file to save to.")
 	} else {
 		err := b.SaveToFile(s[0])
@@ -203,7 +202,7 @@ func replSave(s []string, b backends.Backend) {
 	}
 }
 func replLoad(s []string, b backends.Backend) {
-	if (len(s) < 1) {
+	if len(s) < 1 {
 		fmt.Println("Please provide a file to load from.")
 	} else {
 		err := b.RestoreFromFile(s[0])
@@ -543,7 +542,7 @@ func replListUsers(args []string, b backends.Backend) {
 	} else {
 		fmt.Println("Users:")
 		for _, name := range users {
-			fmt.Println(name.GetUsername()  + ": " + name.GetCredentialLevel().String())
+			fmt.Println(name.GetUsername() + ": " + name.GetCredentialLevel().String())
 		}
 	}
 }

--- a/smoker/src/smoker/smoker/smoker.go
+++ b/smoker/src/smoker/smoker/smoker.go
@@ -12,10 +12,10 @@ import (
 )
 
 const INTRO_TEXT = `Welcome to Smoker - The superior beekeper client`
-const INTRO_ASCII = `   _________ ___  ____  / /_____  _____
-  / ___/ __ ` + "`" + `__ \/ __ \/ //_/ _ \/ ___/
- (__  ) / / / / / /_/ / ,< /  __/ /
-/____/_/ /_/ /_/\____/_/|_|\___/_/
+const INTRO_ASCII = `   _________ ___  ____  / /_____  _____              (  )/
+  / ___/ __ ` + "`" + `__ \/ __ \/ //_/ _ \/ ___/               )(/
+ (__  ) / / / / / /_/ / ,< /  __/ / ________________ ( /)
+/____/_/ /_/ /_/\____/_/|_|\___/_/ ()__)____________)))))
 
 `
 
@@ -27,7 +27,7 @@ func main() {
 
 	intro()
 	initCommands()
-	color.Red("WARNING: Using DUMMY Backend. Your data will not be stored.")
+	color.Red("WARNING: Using LOCAL Backend. YOU are responsible for ensuring your data is safe!")
 
 	// Make our dummy backend
 	backend := backends.NewDummyBackend(10)


### PR DESCRIPTION
See issue #18.

This PR turns smoker into an indepdenent, standalone inventory system, to [avoid reliance on a central server](https://www.reddit.com/r/programming/comments/737ku1/dropbox_v1_api_shutdown_today_expect_lots_of/). 

There is now a save/load command, which serializes the 'Dummy' backend into a 'gob' object, which can be read at a later date to restore the database. Tied with a personal cloud or version control, this can give identical functionality to the full beekeeper suite, while being more robust and having the ability to work completely offline (RoboCup does not have reliable internet).

This also re-structures the public smoker API, to reduce data duplication and data cycles (needed for any form of serialization, ie: json). Json serialization should also be possible actually, but would be a little bit of work setting up a ton of shims.

Reviews are a lie, so if someone decides to relie the lie, send me a review.

Possible todos (I wonder how unproductive I'll feel tomorrow)
- [x] Warn before saving over existing files
- [x] Support `~` in file paths (why is go terrible)
- [ ] Warn before quitting without a saved file
- [ ] Re-run `save` to save to the same file again ([why is this so familiar.. oh.](http://bit.ly/2fVvMgp))
- [ ] Whitespace in path names.

Maybe I can slap a protobuf on the dummy backend soon and make it into a server :D